### PR TITLE
fix(model): change PhotoID type from string to uint64

### DIFF
--- a/model/report/stat.go
+++ b/model/report/stat.go
@@ -23,7 +23,7 @@ type Stat struct {
 	// MatchType 匹配方式：1:精确匹配,2:短语匹配,3:广泛匹配
 	MatchType model.MatchType `json:"match_type,omitempty"`
 	// PhotoID 视频id
-	PhotoID string `json:"photo_id,omitempty"`
+	PhotoID uint64 `json:"photo_id,omitempty"`
 	// PhotoUrl 视频链接
 	PhotoUrl string `json:"photo_url,omitempty"`
 	// ImageToken 封面id


### PR DESCRIPTION
- Updated the type of PhotoID field in the Stat struct from string to uint64.
- This change ensures proper handling of PhotoID as a numeric identifier.
- Adjusted the JSON serialization to reflect the new type.