### PR TITLE
fix: missing parameters channel_id

### DIFF
--- a/model/v2.2/appcenter/subpkg/list_response.go
+++ b/model/v2.2/appcenter/subpkg/list_response.go
@@ -18,6 +18,8 @@ type SubpkgItem struct {
 	AppId int64 `json:"app_id"`
 	//app_privacy_url	String		应用隐私政策链接
 	AppPrivacyUrl string `json:"app_privacy_url"`
+	//channel_id String 渠道号(分包号)
+	ChannelId string `json:"channel_id"`
 	//ios_app_id	String		解析出的iosAppID
 	IosAppId string `json:"ios_app_id"`
 	//offline_app_stores	String		下架的应用商店	"huawei","oppo","vivo","xiaomi","meizu","smartisan"


### PR DESCRIPTION
获取新版分包发布列表【单元创编】
fix: missing parameters channel_id

![image](https://github.com/bububa/kwai-marketing-api/assets/16093534/b31b0379-cc5b-4f8e-9da7-ba5a90a0e927)
