### PR TITLE
fix: 拉取token下授权广告账户接口

### DIFF
--- a/api/oauth/approval_list.go
+++ b/api/oauth/approval_list.go
@@ -19,5 +19,5 @@ func ApprovalList(clt *core.SDKClient, accessToken string, pageNo int, pageSize 
 	if err != nil {
 		return nil, err
 	}
-	return resp.Details, nil
+	return resp.Data.Details, nil
 }

--- a/api/oauth/approval_list.go
+++ b/api/oauth/approval_list.go
@@ -6,11 +6,13 @@ import (
 )
 
 // ApprovalList 拉取token下授权广告账户接口
-func ApprovalList(clt *core.SDKClient, accessToken string) ([]uint64, error) {
+func ApprovalList(clt *core.SDKClient, accessToken string, pageNo int, pageSize int) ([]uint64, error) {
 	req := &oauth.ApprovalListRequest{
 		AppID:       clt.AppID(),
 		Secret:      clt.Secret(),
 		AccessToken: accessToken,
+		PageNo:      pageNo,
+		PageSize:    pageSize,
 	}
 	var resp oauth.ApprovalListResponse
 	err := clt.Post("", req, &resp)

--- a/model/oauth/approval_list.go
+++ b/model/oauth/approval_list.go
@@ -29,6 +29,20 @@ func (r ApprovalListRequest) Encode() []byte {
 
 // ApprovalListResponse 拉取token下授权广告账户接口 API Response
 type ApprovalListResponse struct {
-	// Details 查询获得的广告主 ID
-	Details []uint64 `json:"details,omitempty"`
+	Message string `json:"message,omitempty"` // 返回信息
+	Data    struct {
+		// Details 查询获得的广告主 ID
+		Details []uint64 `json:"details,omitempty"`
+	} `json:"data,omitempty"` // JSON返回值
+	Code int `json:"code,omitempty"` // 返回码
+}
+
+// IsError detect if the response is an error
+func (r *ApprovalListResponse) IsError() bool {
+	return r.Code != 1
+}
+
+// Error implement error interface
+func (r *ApprovalListResponse) Error() string {
+	return r.Message
 }


### PR DESCRIPTION
1. 分页参数为必填。
1. 返回值的code位1是成功（与其他接口不同）。

参考: https://developers.e.kuaishou.com/docs?docType=DSP&documentId=1995&menuId=3797
